### PR TITLE
2016 03 mongoc uri links

### DIFF
--- a/blog/2016-03_mongoc-uri.md
+++ b/blog/2016-03_mongoc-uri.md
@@ -52,8 +52,7 @@ as described in the documentation.
 `retries()`,
 `throttle()`,
 `value-pairs()`,
-and so on
-)
+and so on)
 
 ### The deprecated options of mongodb() destination
 

--- a/blog/2016-03_mongoc-uri.md
+++ b/blog/2016-03_mongoc-uri.md
@@ -2,7 +2,7 @@
 `mongodb-destination-receives-face-lift`
 
 # Focus Keyword
-`mongodb uri`
+`mongodb URI`
 
 # Search engine meta description (at most 142 characters)
 Migrated MongoDB destination driver to the official mongo-c-driver binding
@@ -15,7 +15,7 @@ with URI connection string instead of libmongo-client.
 * mongo-c-driver
 * MongoDB
 * syslog-ng
-* uri
+* URI
 * release
 
 # Categories

--- a/blog/2016-03_mongoc-uri.md
+++ b/blog/2016-03_mongoc-uri.md
@@ -1,4 +1,28 @@
-# The MongoDB destination receives a face-lift
+# URL "slug"
+`mongodb-destination-receives-face-lift`
+
+# Focus Keyword
+`mongodb uri`
+
+# Search engine meta description (at most 142 characters)
+Migrated MongoDB destination driver to the official mongo-c-driver binding
+with URI connection string instead of libmongo-client.
+
+# Post tags
+
+* configuration
+* connection string
+* mongo-c-driver
+* MongoDB
+* syslog-ng
+* uri
+* release
+
+# Categories
+
+* Logging
+
+# Blog post title: The MongoDB destination receives a face-lift
 
 ## Reasons behind the migration
 

--- a/blog/2016-03_mongoc-uri.md
+++ b/blog/2016-03_mongoc-uri.md
@@ -19,6 +19,8 @@ syslog-ng will substitute the given deprecated options to form a URI.
 Note that certain aspects of semantics could also differ
 between the two drivers.
 
+---
+
 Therefore, you should analyze the behavior of your deployed system to ensure
 that the subtle changes in semantics do not cause any regressions.
 A non-exhaustive list of aspects to consider:

--- a/blog/2016-03_mongoc-uri.md
+++ b/blog/2016-03_mongoc-uri.md
@@ -42,7 +42,13 @@ Use the following options for the mongodb() destination:
 
 * `collection`
 * `uri`
-  ([https://docs.mongodb.org/manual/reference/connection-string/](https://docs.mongodb.org/manual/reference/connection-string/))
+
+You can refer to the documentation for more information about the format of the connection `URI` string:
+
+* [https://docs.mongodb.org/manual/reference/connection-string/](https://docs.mongodb.org/manual/reference/connection-string/)
+* [https://api.mongodb.com/java/current/com/mongodb/ConnectionString.html](https://api.mongodb.com/java/current/com/mongodb/ConnectionString.html)
+* [https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html](https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html)
+* [https://mongodb-documentation.readthedocs.io/en/latest/reference/connection-string.html](https://mongodb-documentation.readthedocs.io/en/latest/reference/connection-string.html)
 
 Inherited options are not affected, therefore they can be used as before and
 as described in the documentation.

--- a/blog/2016-03_mongoc-uri.md
+++ b/blog/2016-03_mongoc-uri.md
@@ -3,8 +3,10 @@
 ## Reasons behind the migration
 
 We have migrated to the official mongo-c-driver binding for providing the
-MongoDB destination driver.
-Previously, libmongo-client provided this binding,
+MongoDB destination driver
+in syslog-ng 3.8.
+Previously in syslog-ng 3.7.x and earlier,
+libmongo-client provided this binding,
 mandating its own special syntax.
 
 This change will facilitate future-proof and more fine-grained configuration.


### PR DESCRIPTION
"add list of alternative documentation links
The official one is down at the moment. We will wait for it to
come back online before publishing, but this highlights that
we need backups."
